### PR TITLE
Add release notes page

### DIFF
--- a/main/templates/main/about.html
+++ b/main/templates/main/about.html
@@ -4,9 +4,9 @@
 
 <div class="container-fluid px-5">
     <div class="row mt-3 p-4 mx-auto bg-white shadow card-1000">
-        <h2>GENIE {{ GENIE_VERSION }} - Generation of count data</h2>
+        <h2>GENIE - Generation of count data</h2>
         <hr>
-        <p>Count data are generated to assist with variant interpretation according to the 
+        <p>Count data are generated to assist with variant interpretation according to the
             <a href="https://www.acgs.uk.com/media/12831/svig-uk_guidelines_v10_-_post-acgs_ratification_final_submit01.pdf">
                 UK Somatic Variant Interpretation Guidelines (S-VIG)</a>.
         </p>
@@ -57,8 +57,6 @@
                     <li>
                         Annotations for Hugo_Symbol, Consequence, RefSeq, HGVSc, HGVSp, and Protein_position were
                         replaced with the annotations from VEP v115.2 in GRCh38 prior to counting.
-                        <strong>Note</strong>: the Variant_Classification field is no longer available as this is not
-                        annotated by VEP.
                     </li>
                 </ol>
             </li>
@@ -86,7 +84,7 @@
                     <td><strong>Same amino acid change</strong></td>
                     <td>All variants with <code>HGVSp</code> notation present.</td>
                     <td>
-                        Variants are grouped by <code>Hugo_Symbol</code>, <code>RefSeq</code> 
+                        Variants are grouped by <code>Hugo_Symbol</code>, <code>RefSeq</code>
                         and <code>HGVSp</code> and the number of unique patients are counted.
                     </td>
                 </tr>
@@ -110,7 +108,7 @@
                     </td>
                     <td>
                         For each variant, the deletion range is extracted from the <code>Protein_position</code>
-                         and the number of unique patients with an inframe deletion with the same <code>Hugo_Symbol</code>
+                        and the number of unique patients with an inframe deletion with the same <code>Hugo_Symbol</code>
                          and <code>RefSeq</code> which affects the same range or is nested within the range are counted.
                     </td>
                 </tr>
@@ -544,10 +542,10 @@
 
         <h4>Variants removed</h4>
         <ul>
-            <li>1118 variants which were not annotated against a gene (empty VEP symbol) were removed.</li>
-            <li>3 variants were removed due to a mismatch with the GRCh37 reference when converting from MAF to VCF description.</li>
-            <li>830 variants failed to liftover from GRCh37 -&gt; GRCh38 and were removed.</li>
-            <li>2 variants on contig 22_KI270928v1_alt were removed.</li>
+            <li>Variants which were not annotated against a gene (empty gene symbol) were removed.</li>
+            <li>Variants with a mismatch against the GRCh37 reference when converting from MAF to VCF description were removed.</li>
+            <li>Variants which failed to liftover from GRCh37 -&gt; GRCh38 were removed.</li>
+            <li>Variants on alt contigs were removed.</li>
         </ul>
     </div>
 </div>

--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -31,7 +31,7 @@
                 <p class="mb-1">
                     <a class="primary-link" href="{% url 'main:about' %}">Information about generation of patient count data</a>
                 </p>
-                <p class="mb=1">
+                <p>
                     <a class="primary-link" href="{% url 'main:release_notes' %}">Release notes</a>
                 </p>
             </div>

--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -28,8 +28,11 @@
         </div>
         <div class="row">
             <div class="col-12 px-5">
-                <p>
+                <p class="mb-1">
                     <a class="primary-link" href="{% url 'main:about' %}">Information about generation of patient count data</a>
+                </p>
+                <p class="mb=1">
+                    <a class="primary-link" href="{% url 'main:release_notes' %}">Release notes</a>
                 </p>
             </div>
         </div>

--- a/main/templates/main/release_notes.html
+++ b/main/templates/main/release_notes.html
@@ -1,0 +1,157 @@
+{% extends "main/base.html" %}
+
+{% block content %}
+
+<div class="container-fluid px-5">
+    <div class="row mt-3 p-4 mx-auto bg-white shadow card-1000">
+      <h1>Release Notes</h1>
+
+      <h2>1.1.0-beta - June 2026</h2>
+
+      <p><h3>Summary</h3>
+      This update uses the latest version of the GENIE public dataset and includes changes to variant counts due to annotation of variants in GRCh38 against updated transcripts, as well as updates to the user interface to incorporate these changes.</p>
+
+      <p><h3>What&#39;s new</h3></p>
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Change</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Data</td>
+            <td>Update to GENIE v19 dataset</td>
+            <td>
+              This release has updated to use
+              <a href="https://www.synapse.org/Synapse:syn72382128">Cohort v19.0-public</a> of the AACR Project GENIE dataset which contains 271,837 samples and 227,696 patients.
+            </td>
+          </tr>
+          <tr>
+            <td rowspan="3">Counting</td>
+            <td>Annotation in GRCh38</td>
+            <td>
+              Variants are now annotated in GRCh38 using latest gene symbols and against
+              RefSeq <a href="https://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick">MANE transcripts as priority</a>.
+            </td>
+          </tr>
+          <tr>
+            <td>Variant type classification</td>
+            <td>
+              The variant Consequence determined by VEP is now used to determine variant type; frameshift (truncating) and nonsense variants are those with a consequence of "frameshift_variant" or "stop_gained" which have "Ter" (and not "ext") in the <code>HGVSp</code> notation. Inframe deletions are those with a consequence of "inframe_deletion".
+              Previously the <code>Variant_Classification</code> field was used; however, this is calculated by cBioPortal/MSKCC's internal processes and is not available following re-annotation in GRCh38.
+            </td>
+          </tr>
+          <tr>
+            <td>Variant position/range</td>
+            <td>
+              The position for frameshift (truncating) and nonsense variants and the range
+              for inframe deletions is now determined by the <code>Protein_position</code>
+              field, rather than the <code>HGVS</code> notation.
+            </td>
+          </tr>
+          <tr>
+            <td rowspan="2">Website</td>
+            <td>Column changes</td>
+            <td>
+              The <code>Variant_Classification</code> field for each variant has been removed.
+              The <code>Protein_position</code> field for each variant has been added.
+            </td>
+          </tr>
+          <tr>
+            <td>Documentation</td>
+            <td>
+              The "Information about generation of patient count data" page has been updated
+              to reflect the above changes.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+
+      <p><h5>Variants removed in this version</h5></p>
+      <ul>
+          <li>1118 variants which were not annotated against a gene (empty gene symbol) were removed.</li>
+          <li>3 variants with a mismatch against the GRCh37 reference when converting from MAF to VCF description were removed.</li>
+          <li>830 variants which failed to liftover from GRCh37 -&gt; GRCh38 were removed.</li>
+          <li>2 variants on contig 22_KI270928v1_alt were removed.</li>
+      </ul>
+
+
+      <h2 class="mt-4">1.0.0-beta - September 2025</h2>
+
+      <p><h3>Summary</h3>
+      Initial beta release of the NHS GENIE website, providing patient counts for variants in the AACR Project GENIE dataset. Searching can be performed by gene symbol, chromosomal position, and chromosomal region, with aggregation of counts across multiple variant types and cancer groupings.</p>
+
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Change</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Data</td>
+            <td>Dataset</td>
+            <td>
+              This release uses the
+              <a href="https://www.synapse.org/Synapse:syn64501552">Cohort v17.0-public</a> dataset of the AACR Project GENIE dataset which contains 229,453 samples and 196,244 patients.
+            </td>
+          </tr>
+          <tr>
+            <td rowspan="4">Counting</td>
+            <td>Same nucleotide change counts</td>
+            <td>
+              Counts of unique patients grouped by GRCh38 chromosome, position, reference and alternate allele.
+            </td>
+          </tr>
+          <tr>
+            <td>Same amino acid change counts</td>
+            <td>
+              Counts of unique patients grouped by transcript and protein change (<code>HGVSp</code>).
+            </td>
+          </tr>
+          <tr>
+            <td>Downstream frameshift (truncating) and nonsense counts</td>
+            <td>
+              Counts of unique patients with truncating variants affecting the same or downstream position (extracted from the <code>HGVSc</code> notation) within a gene and transcript. These are classed as any variants with a <code>Variant_Classification</code> of "Frame_Shift_Del", "Frame_Shift_Ins" or "Nonsense_Mutation" which have "Ter" in the <code>HGVSp</code> notation.
+            </td>
+          </tr>
+          <tr>
+            <td>Inframe deletion counts</td>
+            <td>
+              Counts of unique patients with the same or nested inframe deletions (extracted from the <code>HGVSp</code> notation) within the same gene and transcript. Inframe deletions are determined by the "In_Frame_Del" value for <code>Variant_Classification</code>.
+            </td>
+          </tr>
+          <tr>
+            <td rowspan="1">Annotation</td>
+            <td>Annotations</td>
+            <td>
+              Counts use the annotations, including gene symbols and transcripts, which are supplied in the GENIE bulk download. Thirty-nine genes contain counts for multiple transcripts.
+            </td>
+          </tr>
+          <tr>
+            <td rowspan="1">Website</td>
+            <td>Initial beta release</td>
+            <td>
+              Search functionality included for gene symbols, chromosomal positions, and chromosomal regions, with patient counts available by cancer type and cancer grouping.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p><h5>Variants removed in this version</h5></p>
+      <ul>
+          <li>732 variants with a gene symbol of "Unknown" were removed.</li>
+          <li>3 variants with a mismatch against the GRCh37 reference when converting from MAF to VCF description were removed.</li>
+          <li>684 variants which failed to liftover from GRCh37 -&gt; GRCh38 were removed.</li>
+          <li>2 variants on contig 22_KI270928v1_alt were removed.</li>
+      </ul>
+
+  </div>
+</div>
+{% endblock %}

--- a/main/urls.py
+++ b/main/urls.py
@@ -6,6 +6,7 @@ app_name = 'main'
 urlpatterns = [
     path('', views.index, name='index'),
     path('about/', views.about, name='about'),
+    path('release_notes/', views.release_notes, name='release_notes'),
     path('variants/', views.variants, name='variants'),
     path('search/', views.search_view, name='search'),
     path('ajax_variants/', views.ajax_variants, name='ajax_variants'),

--- a/main/views.py
+++ b/main/views.py
@@ -17,6 +17,9 @@ def about(request):
     """A page with information about generation of patient count data."""
     return render(request, 'main/about.html')
 
+def release_notes(request):
+    """A page with information about release notes for each version"""
+    return render(request, 'main/release_notes.html')
 
 def search_view(request):
     """Main website search that is available on all website pages.


### PR DESCRIPTION
- Add new release notes HTML page with details on first beta version and second beta version
- Add link to release notes page in homepage (index)
- Update urls and views to include release notes page
- Update about page to be slightly more generic, since info about changes is in release notes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/genie_nhs_website/16)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Release Notes page accessible from the home page to keep users informed about updates.

* **Documentation**
  * Updated the About page with clearer explanations of patient-level count generation and revised variant removal criteria descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->