### PR TITLE
docs: add GOOGLE_ANALYTICS_ID to SSM env example

### DIFF
--- a/docs/deployment-and-testing.md
+++ b/docs/deployment-and-testing.md
@@ -133,6 +133,7 @@ These resources must exist before Terraform can be initialised:
    GENIE_VERSION=v19
    GENIE_VCF=GENIE_v19_GRCh38_counts_v1.0.0.vcf.gz
    GENIE_CANCER_TYPES_CSV=GENIE_v19_cancer_types.csv
+   GOOGLE_ANALYTICS_ID=<GA4-measurement-id>
    ```
 
    See `README.md` for the full list of supported environment variables.


### PR DESCRIPTION
## Summary
- Adds `GOOGLE_ANALYTICS_ID` to the SSM `.env` example in `docs/deployment-and-testing.md`

GA tag `G-ZZ9LTYXMQZ` was added to the prod SSM parameter this session. The docs example now reflects it so future reprovisioning includes the GA tag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/genie_nhs_website/19)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment and testing documentation to include Google Analytics configuration requirements in the environment setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->