### PR TITLE
docs: add AWS_PROFILE, ssh-agent, and tf-init notes to deploy instructions

### DIFF
--- a/docs/deployment-and-testing.md
+++ b/docs/deployment-and-testing.md
@@ -270,8 +270,12 @@ To deploy the latest code to a running instance:
 
 ```bash
 ssh-add ~/.ssh/nhs-genie.pem   # ensure key is in agent first
-make deploy ENV=prod
+# if no agent is running: eval $(ssh-agent -s) && ssh-add ~/.ssh/nhs-genie.pem
+AWS_PROFILE=genie-website make deploy ENV=prod
 ```
+
+> **Note:** If Terraform has not been initialised on this machine, run
+> `AWS_PROFILE=genie-website make tf-init` first.
 
 This SSHes to the instance and runs:
 1. `git pull origin main`


### PR DESCRIPTION
Fixes gaps in the deployment section of `docs/deployment-and-testing.md`:

- Add missing `AWS_PROFILE=genie-website` to the deploy command
- Add note for starting an ssh-agent if one isn't running
- Add note to run `make tf-init` if Terraform hasn't been initialised on the machine

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/genie_nhs_website/21)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions with additional configuration steps and prerequisite setup notes to ensure successful deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->