### PR TITLE
fix: restrict security group egress to required ports only (AWS-0104)

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -73,11 +73,53 @@ resource "aws_vpc_security_group_ingress_rule" "https" {
   cidr_ipv4         = "0.0.0.0/0"
 }
 
-resource "aws_vpc_security_group_egress_rule" "all_outbound" {
+# --- Egress rules (least-privilege) ---
+# Replaces the previous catch-all rule (ip_protocol = "-1") to satisfy
+# Trivy AWS-0104. Only ports confirmed as necessary by user_data.sh are opened.
+
+resource "aws_vpc_security_group_egress_rule" "egress_https" {
   security_group_id = aws_security_group.genie.id
-  description       = "All outbound"
-  ip_protocol       = "-1"
+  description       = "HTTPS outbound (apt, Docker, AWS APIs, GitHub, MaxMind, PyPI)"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
   cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_egress_rule" "egress_http" {
+  security_group_id = aws_security_group.genie.id
+  description       = "HTTP outbound (apt mirrors, Lets Encrypt ACME challenge)"
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_egress_rule" "egress_dns" {
+  security_group_id = aws_security_group.genie.id
+  description       = "DNS resolution (UDP) to VPC resolver"
+  from_port         = 53
+  to_port           = 53
+  ip_protocol       = "udp"
+  cidr_ipv4         = "169.254.169.253/32"
+}
+
+resource "aws_vpc_security_group_egress_rule" "egress_dns_tcp" {
+  security_group_id = aws_security_group.genie.id
+  description       = "DNS resolution (TCP) to VPC resolver - large responses"
+  from_port         = 53
+  to_port           = 53
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "169.254.169.253/32"
+}
+
+resource "aws_vpc_security_group_egress_rule" "egress_ntp" {
+  security_group_id = aws_security_group.genie.id
+  description       = "NTP time sync (UDP) to AWS time sync service"
+  from_port         = 123
+  to_port           = 123
+  ip_protocol       = "udp"
+  cidr_ipv4         = "169.254.169.123/32"
 }
 
 # --- EC2 instance ---

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -5,7 +5,7 @@ key_pair_name   = "nhs-genie"
 domain          = "genie.genomics-resources.uk"
 route53_zone_id = "Z09949371PEDMO2FEKH29"
 s3_data_bucket  = "genie-website-data"
-alert_email     = "a-bioinformatics-inbox@nhs.net"
+alert_email     = "cuh.bioinformatics.group@nhs.net"
 ssh_cidr_blocks = ["145.40.188.80/32"]
 
 # UK geo-restriction (Nginx GeoIP2). Requires the MaxMind GeoLite2 licence key


### PR DESCRIPTION
## Summary

Resolves Trivy code scanning alert [#1](https://github.com/eastgenomics/genie_nhs_website/security/code-scanning/1) — **CRITICAL** misconfiguration AWS-0104.

The existing egress rule allowed all protocols on all ports to `0.0.0.0/0`, giving a compromised instance unrestricted outbound internet access. This replaces it with five least-privilege rules covering only what `user_data.sh` demonstrably requires:

| Rule | Protocol | Port | Destination |
|---|---|---|---|
| `egress_https` | TCP | 443 | `0.0.0.0/0` |
| `egress_http` | TCP | 80 | `0.0.0.0/0` |
| `egress_dns` | UDP | 53 | `169.254.169.253/32` (VPC resolver) |
| `egress_dns_tcp` | TCP | 53 | `169.254.169.253/32` (VPC resolver) |
| `egress_ntp` | UDP | 123 | `169.254.169.123/32` (AWS time sync) |

Also updates `alert_email` to `cuh.bioinformatics.group@nhs.net`.

## Testing

Applied and smoke-tested on the UAT environment (`uat.genie.genomics-resources.uk`) before this PR:
- ✅ HTTPS outbound (`curl -I https://github.com`)
- ✅ HTTP outbound (`curl -I http://archive.ubuntu.com`)
- ✅ DNS resolution (`dig github.com @169.254.169.253`)
- ✅ NTP sync (`chronyc tracking`)
- ✅ Docker pull (`docker pull hello-world`)
- ✅ App serving (`curl -I http://localhost`)

## Post-merge

After merging, apply to prod:
```bash
cd terraform
export AWS_PROFILE=genie-website
terraform workspace select prod
terraform apply
```
Note: the SNS alert subscription will be replaced (old email → `cuh.bioinformatics.group@nhs.net`) — confirm the subscription when the AWS notification email arrives.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/genie_nhs_website/22)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified outbound network connectivity configuration to restrict access to specific services and protocols, including HTTPS and HTTP for general connectivity, DNS queries to designated infrastructure resolvers, and NTP for time synchronisation, with targeted IP restrictions where required.
  * Updated alert notification email address for system alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->