### PR TITLE
docs: add beta redirect plan and Slack SNS subscription

### DIFF
--- a/docs/redirect-beta-to-prod.md
+++ b/docs/redirect-beta-to-prod.md
@@ -1,0 +1,176 @@
+# Plan: Redirect beta.genomics-resources.uk → genie.genomics-resources.uk
+
+## Background
+
+`beta.genomics-resources.uk` is a legacy EC2 instance (`i-07647078253ae1351`,
+`t3.large`) in AWS account `471112938470`, predating the current
+`genie.genomics-resources.uk` infrastructure. It runs the same Django/Gunicorn
+application via Docker, served through Nginx with a valid Let's Encrypt
+certificate.
+
+The goal is to replace the application with a brief informational page that
+automatically redirects users to `https://genie.genomics-resources.uk` after a
+short delay, so they are informed rather than silently bounced.
+
+---
+
+## Approach
+
+All changes are made directly on the beta server — no Terraform is involved.
+The Django/Docker application can remain running untouched. Only the Nginx
+configuration changes.
+
+**Mechanism:** Nginx stops proxying to the app and instead serves a single
+static HTML page. The page:
+- Explains that the beta site has moved
+- Provides a direct link in case the redirect does not fire
+- Redirects to `https://genie.genomics-resources.uk` after 8 seconds via
+  `<meta http-equiv="refresh">`
+
+This is the simplest approach with no application code changes and a clean
+rollback path.
+
+---
+
+## Implementation Steps
+
+### Step 1 — Write the redirect page
+
+Create `/var/www/html/moved.html` on the beta server:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="refresh" content="8; url=https://genie.genomics-resources.uk">
+  <title>GENIE has moved</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: #f0f4f8;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+    }
+    .box {
+      background: white;
+      border-top: 6px solid #005eb8;
+      border-radius: 4px;
+      padding: 2.5rem 3rem;
+      max-width: 540px;
+      text-align: center;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    h1 { color: #005eb8; font-size: 1.5rem; margin-bottom: 1rem; }
+    p  { color: #333; line-height: 1.6; }
+    a  { color: #005eb8; font-weight: bold; }
+    .countdown { font-size: 2rem; font-weight: bold; color: #005eb8; margin: 1.5rem 0; }
+  </style>
+  <script>
+    var seconds = 8;
+    function tick() {
+      var el = document.getElementById('count');
+      if (el) { el.textContent = seconds; }
+      if (seconds <= 0) {
+        window.location.href = 'https://genie.genomics-resources.uk';
+      }
+      seconds--;
+      setTimeout(tick, 1000);
+    }
+    window.onload = tick;
+  </script>
+</head>
+<body>
+  <div class="box">
+    <h1>GENIE has a new home</h1>
+    <p>
+      The NHS GENIE database has been updated to release 19 and has moved to a new address (please update your bookmarks).
+      You will be redirected automatically in:
+    </p>
+    <div class="countdown"><span id="count">8</span>s</div>
+    <p>
+      If you are not redirected, please click the link below:
+    </p>
+    <p>
+      <a href="https://genie.genomics-resources.uk">
+        https://genie.genomics-resources.uk
+      </a>
+    </p>
+  </div>
+</body>
+</html>
+```
+
+### Step 2 — Update the Nginx configuration
+
+Replace the `proxy_pass` block in the `beta.genomics-resources.uk` server
+block with a directive to serve `moved.html` for all requests:
+
+**Current `location /` block:**
+```nginx
+location / {
+    proxy_pass http://127.0.0.1:8000;
+    proxy_redirect off;
+    proxy_connect_timeout 5s;
+    proxy_send_timeout 60s;
+    proxy_read_timeout 60s;
+}
+```
+
+**Replace with:**
+```nginx
+location / {
+    root /var/www/html;
+    try_files /moved.html =404;
+}
+```
+
+Also remove the `/static/` location block — it is no longer needed once the
+app is no longer being proxied.
+
+### Step 3 — Test and reload Nginx
+
+```bash
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+### Step 4 — Verify
+
+- Visit `https://beta.genomics-resources.uk` — the informational page should
+  appear and redirect to `https://genie.genomics-resources.uk` after 8 seconds.
+- Confirm `https` works (existing Let's Encrypt cert is still valid and managed
+  by Certbot).
+- Confirm `http://beta.genomics-resources.uk` still redirects to `https`
+  (existing Certbot-managed HTTP→HTTPS redirect remains untouched).
+
+---
+
+## Rollback
+
+To restore the original behaviour, revert the `location /` block and
+`location /static/` block to their previous state and reload Nginx:
+
+```bash
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+The Docker application remains running throughout and can be proxied again
+immediately without any restart.
+
+---
+
+## Future: Decommissioning the Server
+
+Once satisfied that users have transitioned, the beta server can be stopped and
+eventually terminated. Before doing so:
+
+1. Confirm the Let's Encrypt cert renewal cron is not depended on elsewhere.
+2. Check whether `genomics-resources.uk` Route 53 hosted zone and any other
+   DNS records in account `471112938470` need to be preserved.
+3. Terminate `i-07647078253ae1351` and release the associated EIP/public IP.
+4. Consider whether the `genomics-resources.uk` domain registration and hosted
+   zone should be migrated to the `804761969039` account or allowed to lapse.

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -14,6 +14,13 @@ resource "aws_sns_topic_subscription" "email" {
   endpoint  = var.alert_email
 }
 
+resource "aws_sns_topic_subscription" "slack_email" {
+  count     = local.is_prod && var.alert_slack_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.genie_alerts[0].arn
+  protocol  = "email"
+  endpoint  = var.alert_slack_email
+}
+
 # --- CPU utilisation alarm (>80% for 5 minutes) ---
 
 resource "aws_cloudwatch_metric_alarm" "cpu_high" {

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -6,6 +6,7 @@ domain          = "genie.genomics-resources.uk"
 route53_zone_id = "Z09949371PEDMO2FEKH29"
 s3_data_bucket  = "genie-website-data"
 alert_email     = "cuh.bioinformatics.group@nhs.net"
+alert_slack_email = "g3p4g8o0i4h6w6s5@binfx.slack.com"
 ssh_cidr_blocks = ["145.40.188.80/32"]
 
 # UK geo-restriction (Nginx GeoIP2). Requires the MaxMind GeoLite2 licence key

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,6 +29,12 @@ variable "alert_email" {
   type        = string
 }
 
+variable "alert_slack_email" {
+  description = "Optional Slack email integration address for CloudWatch alarm notifications"
+  type        = string
+  default     = ""
+}
+
 variable "ssh_cidr_blocks" {
   description = "CIDR blocks allowed to SSH (e.g. office/VPN range). No default — must be set explicitly."
   type        = list(string)


### PR DESCRIPTION
## Changes

### `docs/redirect-beta-to-prod.md`
Adds the plan and record for redirecting the legacy `beta.genomics-resources.uk` instance to `genie.genomics-resources.uk`. The redirect has already been implemented on the server — Nginx now serves a static informational page with an 8-second countdown before auto-redirecting users. The doc records the approach, Nginx changes, rollback steps, and future decommissioning considerations.

### Slack SNS subscription (`terraform/cloudwatch.tf`, `variables.tf`, `terraform.tfvars`)
Adds a second CloudWatch alarm subscriber — a Slack email integration endpoint — alongside the existing `cuh.bioinformatics.group@nhs.net` subscription. The subscription was created via CLI, confirmed, and tested; this commit brings it under Terraform management.

- New optional variable `alert_slack_email` (defaults to `""`) — no subscription is created if unset
- Existing subscription to `cuh.bioinformatics.group@nhs.net` is unchanged

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/genie_nhs_website/23)
<!-- Reviewable:end -->
