### PR TITLE
fix: suppress Trivy AWS-0104 on intentional wide-destination egress rules

### DIFF
--- a/docs/redirect-beta-to-prod.md
+++ b/docs/redirect-beta-to-prod.md
@@ -110,7 +110,7 @@ Create `/var/www/html/moved.html` on the beta server:
 Replace the `proxy_pass` block in the `beta.genomics-resources.uk` server
 block with a directive to serve `moved.html` for all requests:
 
-**Current `location /` block** (as per `scripts/nginx-genie.conf`):
+**Current `location /` block** (same proxy pattern as `scripts/nginx-genie.conf`):
 ```nginx
 location / {
     proxy_pass http://127.0.0.1:8000;

--- a/docs/redirect-beta-to-prod.md
+++ b/docs/redirect-beta-to-prod.md
@@ -110,14 +110,14 @@ Create `/var/www/html/moved.html` on the beta server:
 Replace the `proxy_pass` block in the `beta.genomics-resources.uk` server
 block with a directive to serve `moved.html` for all requests:
 
-**Current `location /` block:**
+**Current `location /` block** (as per `scripts/nginx-genie.conf`):
 ```nginx
 location / {
     proxy_pass http://127.0.0.1:8000;
-    proxy_redirect off;
-    proxy_connect_timeout 5s;
-    proxy_send_timeout 60s;
-    proxy_read_timeout 60s;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
 }
 ```
 
@@ -128,9 +128,6 @@ location / {
     try_files /moved.html =404;
 }
 ```
-
-Also remove the `/static/` location block — it is no longer needed once the
-app is no longer being proxied.
 
 ### Step 3 — Test and reload Nginx
 
@@ -151,8 +148,8 @@ sudo nginx -t && sudo systemctl reload nginx
 
 ## Rollback
 
-To restore the original behaviour, revert the `location /` block and
-`location /static/` block to their previous state and reload Nginx:
+To restore the original behaviour, revert the `location /` block to its
+previous state (see Step 2 above for the full original block) and reload Nginx:
 
 ```bash
 sudo nginx -t && sudo systemctl reload nginx

--- a/docs/redirect-beta-to-prod.md
+++ b/docs/redirect-beta-to-prod.md
@@ -1,0 +1,176 @@
+# Plan: Redirect beta.genomics-resources.uk → genie.genomics-resources.uk
+
+## Background
+
+`beta.genomics-resources.uk` is a legacy EC2 instance (`i-07647078253ae1351`,
+`t3.large`) in AWS account `471112938470`, predating the current
+`genie.genomics-resources.uk` infrastructure. It runs the same Django/Gunicorn
+application via Docker, served through Nginx with a valid Let's Encrypt
+certificate.
+
+The goal is to replace the application with a brief informational page that
+automatically redirects users to `https://genie.genomics-resources.uk` after a
+short delay, so they are informed rather than silently bounced.
+
+---
+
+## Approach
+
+All changes are made directly on the beta server — no Terraform is involved.
+The Django/Docker application can remain running untouched. Only the Nginx
+configuration changes.
+
+**Mechanism:** Nginx stops proxying to the app and instead serves a single
+static HTML page. The page:
+- Explains that the beta site has moved
+- Provides a direct link in case the redirect does not fire
+- Redirects to `https://genie.genomics-resources.uk` after 8 seconds via
+  `<meta http-equiv="refresh">`
+
+This is the simplest approach with no application code changes and a clean
+rollback path.
+
+---
+
+## Implementation Steps
+
+### Step 1 — Write the redirect page
+
+Create `/var/www/html/moved.html` on the beta server:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="refresh" content="8; url=https://genie.genomics-resources.uk">
+  <title>GENIE has moved</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: #f0f4f8;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+    }
+    .box {
+      background: white;
+      border-top: 6px solid #005eb8;
+      border-radius: 4px;
+      padding: 2.5rem 3rem;
+      max-width: 540px;
+      text-align: center;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    h1 { color: #005eb8; font-size: 1.5rem; margin-bottom: 1rem; }
+    p  { color: #333; line-height: 1.6; }
+    a  { color: #005eb8; font-weight: bold; }
+    .countdown { font-size: 2rem; font-weight: bold; color: #005eb8; margin: 1.5rem 0; }
+  </style>
+  <script>
+    var seconds = 8;
+    function tick() {
+      var el = document.getElementById('count');
+      if (el) { el.textContent = seconds; }
+      if (seconds <= 0) {
+        window.location.href = 'https://genie.genomics-resources.uk';
+      }
+      seconds--;
+      setTimeout(tick, 1000);
+    }
+    window.onload = tick;
+  </script>
+</head>
+<body>
+  <div class="box">
+    <h1>GENIE has a new home</h1>
+    <p>
+      The NHS GENIE database has been updated to release 19 and has moved to a new address (please update your bookmarks).
+      You will be redirected automatically in:
+    </p>
+    <div class="countdown"><span id="count">8</span>s</div>
+    <p>
+      If you are not redirected, please click the link below:
+    </p>
+    <p>
+      <a href="https://genie.genomics-resources.uk">
+        https://genie.genomics-resources.uk
+      </a>
+    </p>
+  </div>
+</body>
+</html>
+```
+
+### Step 2 — Update the Nginx configuration
+
+Replace the `proxy_pass` block in the `beta.genomics-resources.uk` server
+block with a directive to serve `moved.html` for all requests:
+
+**Current `location /` block:**
+```nginx
+location / {
+    proxy_pass http://127.0.0.1:8000;
+    proxy_redirect off;
+    proxy_connect_timeout 5s;
+    proxy_send_timeout 60s;
+    proxy_read_timeout 60s;
+}
+```
+
+**Replace with:**
+```nginx
+location / {
+    root /var/www/html;
+    try_files /moved.html =404;
+}
+```
+
+Also remove the `/static/` location block — it is no longer needed once the
+app is no longer being proxied.
+
+### Step 3 — Test and reload Nginx
+
+```bash
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+### Step 4 — Verify
+
+- Visit `https://beta.genomics-resources.uk` — the informational page should
+  appear and redirect to `https://genie.genomics-resources.uk` after 8 seconds.
+- Confirm `https` works (existing Let's Encrypt cert is still valid and managed
+  by Certbot).
+- Confirm `http://beta.genomics-resources.uk` still redirects to `https`
+  (existing Certbot-managed HTTP→HTTPS redirect remains untouched).
+
+---
+
+## Rollback
+
+To restore the original behaviour, revert the `location /` block and
+`location /static/` block to their previous state and reload Nginx:
+
+```bash
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+The Docker application remains running throughout and can be proxied again
+immediately without any restart.
+
+---
+
+## Future: Decommissioning the Server
+
+Once satisfied that users have transitioned, the beta server can be stopped and
+eventually terminated. Before doing so:
+
+1. Confirm the Let's Encrypt cert renewal cron is not depended on elsewhere.
+2. Check whether `genomics-resources.uk` Route 53 hosted zone and any other
+   DNS records in account `471112938470` need to be preserved.
+3. Terminate `i-07647078253ae1351` and release the associated EIP/public IP.
+4. Consider whether the `genomics-resources.uk` domain registration and hosted
+   zone should be migrated to the `804761969039` account or allowed to lapse.

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -14,6 +14,13 @@ resource "aws_sns_topic_subscription" "email" {
   endpoint  = var.alert_email
 }
 
+resource "aws_sns_topic_subscription" "slack_email" {
+  count     = local.is_prod && var.alert_slack_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.genie_alerts[0].arn
+  protocol  = "email"
+  endpoint  = var.alert_slack_email
+}
+
 # --- CPU utilisation alarm (>80% for 5 minutes) ---
 
 resource "aws_cloudwatch_metric_alarm" "cpu_high" {

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -77,6 +77,7 @@ resource "aws_vpc_security_group_ingress_rule" "https" {
 # Replaces the previous catch-all rule (ip_protocol = "-1") to satisfy
 # Trivy AWS-0104. Only ports confirmed as necessary by user_data.sh are opened.
 
+#trivy:ignore:AVD-AWS-0104 -- destination cannot be restricted: external services (apt, Docker Hub, GitHub, MaxMind, PyPI, AWS APIs) use variable/CDN IPs
 resource "aws_vpc_security_group_egress_rule" "egress_https" {
   security_group_id = aws_security_group.genie.id
   description       = "HTTPS outbound (apt, Docker, AWS APIs, GitHub, MaxMind, PyPI)"
@@ -86,6 +87,7 @@ resource "aws_vpc_security_group_egress_rule" "egress_https" {
   cidr_ipv4         = "0.0.0.0/0"
 }
 
+#trivy:ignore:AVD-AWS-0104 -- destination cannot be restricted: apt mirrors and Let's Encrypt use variable/CDN IPs
 resource "aws_vpc_security_group_egress_rule" "egress_http" {
   security_group_id = aws_security_group.genie.id
   description       = "HTTP outbound (apt mirrors, Lets Encrypt ACME challenge)"

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -6,6 +6,7 @@ domain          = "genie.genomics-resources.uk"
 route53_zone_id = "Z09949371PEDMO2FEKH29"
 s3_data_bucket  = "genie-website-data"
 alert_email     = "cuh.bioinformatics.group@nhs.net"
+alert_slack_email = "g3p4g8o0i4h6w6s5@binfx.slack.com"
 ssh_cidr_blocks = ["145.40.188.80/32"]
 
 # UK geo-restriction (Nginx GeoIP2). Requires the MaxMind GeoLite2 licence key

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -6,7 +6,9 @@ domain          = "genie.genomics-resources.uk"
 route53_zone_id = "Z09949371PEDMO2FEKH29"
 s3_data_bucket  = "genie-website-data"
 alert_email     = "cuh.bioinformatics.group@nhs.net"
-alert_slack_email = "g3p4g8o0i4h6w6s5@binfx.slack.com"
+# alert_slack_email is intentionally omitted from VCS — pass it at apply time:
+#   terraform apply -var="alert_slack_email=<slack-channel-email>"
+# See variables.tf: defaults to "" (subscription skipped) if not supplied.
 ssh_cidr_blocks = ["145.40.188.80/32"]
 
 # UK geo-restriction (Nginx GeoIP2). Requires the MaxMind GeoLite2 licence key

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,6 +29,12 @@ variable "alert_email" {
   type        = string
 }
 
+variable "alert_slack_email" {
+  description = "Optional Slack email integration address for CloudWatch alarm notifications"
+  type        = string
+  default     = ""
+}
+
 variable "ssh_cidr_blocks" {
   description = "CIDR blocks allowed to SSH (e.g. office/VPN range). No default — must be set explicitly."
   type        = list(string)


### PR DESCRIPTION
## Summary

The scheduled Trivy scan is raising two new AWS-0104 alerts (#2 and #3) against `terraform/ec2.tf`:

| Alert | Resource | Line | Reason flagged |
|---|---|---|---|
| #3 | `egress_https` (TCP/443) | 86 | `cidr_ipv4 = "0.0.0.0/0"` |
| #2 | `egress_http` (TCP/80) | 95 | `cidr_ipv4 = "0.0.0.0/0"` |

These alerts are a continuation of the same finding that was fixed in PR #22. That PR correctly replaced the all-protocol catch-all (`ip_protocol = "-1"`) with port-specific rules, but Trivy AWS-0104 fires on **any** egress to `0.0.0.0/0` — even when restricted to a specific port.

The `0.0.0.0/0` destination on ports 80 and 443 is intentional and unavoidable: the services the instance needs to reach at bootstrap and runtime (apt mirrors, Docker Hub, GitHub, MaxMind, PyPI, Let's Encrypt ACME, AWS APIs) all operate from variable/CDN IPs that cannot be enumerated in a CIDR list.

The DNS (UDP/TCP to `169.254.169.253/32`) and NTP (UDP to `169.254.169.123/32`) rules already use restricted CIDRs and are unaffected.

## Change

Add `#trivy:ignore:AVD-AWS-0104` inline suppression comments immediately above the two resources, with rationale text naming the services that require unrestricted internet egress.

No Terraform resources are added, removed, or modified — this is a comment-only change.

## Test plan

- [ ] Scheduled scan (or manual workflow dispatch of `scheduled-scan.yml`) no longer raises AWS-0104 alerts against `egress_https` or `egress_http`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/genie_nhs_website/24)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new redirect page and rollout guidance for moving the beta site to the main production site.
  * Enabled optional CloudWatch alarm notifications to be sent to an email address in production.

* **Bug Fixes**
  * Updated the beta server setup to serve the redirect page directly, avoiding the old application proxy path.

* **Chores**
  * Suppressed selected infrastructure security scan warnings where appropriate.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->