### PR TITLE
fix: bump django 5.2.15 → 5.2.16 (CVE-2026-48588, CVE-2026-53877, CVE-2026-53878)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==5.2.15
+django==5.2.16
 fontawesomefree==6.6.0
 gunicorn==23.0.0
 pandas==2.3.1


### PR DESCRIPTION
## Summary

Bumps `django` from `5.2.15` to `5.2.16` to resolve three CVEs identified by the scheduled pip-audit scan on 2026-07-13.

## CVEs addressed

| PYSEC ID | CVE | Summary | CVSS |
|---|---|---|---|
| PYSEC-2026-2090 | CVE-2026-48588 | Cached Set-Cookie response may expose private data | 5.3 Medium |
| PYSEC-2026-2091 | CVE-2026-53877 | Heap buffer over-read in GDALRaster (GeoDjango) | Low |
| PYSEC-2026-2092 | CVE-2026-53878 | Header injection via DomainNameValidator | Low |

## GENIE applicability

All three CVEs are **not exploitable** in the NHS GENIE Variant Browser:
- CVE-2026-48588 requires `UpdateCacheMiddleware`/`cache_page()` — GENIE uses no cache middleware and is unauthenticated by design
- CVE-2026-53877 requires `django.contrib.gis`/`GDALRaster` — GENIE does not use GeoDjango
- CVE-2026-53878 requires custom `DomainNameValidator` use outside form fields — GENIE does not use this

## Governance

- **Governance tier:** NORMAL SIGNOFF (CVEs do not affect GENIE's variant query path)
- **Security finding document:** https://cuhbioinformatics.atlassian.net/wiki/spaces/DV/pages/4746543220
- **GOVR Supply Chain Item:** created for Django (Data-handling, CVE scan result: Issues-addressed)

## Change

```
requirements.txt: django==5.2.15 → django==5.2.16
```

No functional changes. Backwards-compatible upgrade. Docker rebuild on deploy will pick up the new version.

## References
- [Django security releases 5.2.16 / 6.0.7](https://www.djangoproject.com/weblog/2026/jul/07/security-releases/)
- [pip-audit scan result](https://github.com/eastgenomics/genie_nhs_website/actions/runs/29236816413/job/86773295377)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/genie_nhs_website/28)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Django to version 5.2.16.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->